### PR TITLE
Hero mobile responsive fixes

### DIFF
--- a/es/index.html
+++ b/es/index.html
@@ -48,7 +48,7 @@
     <link rel="preload" href="/fonts/poppins-800.woff2?v=60bf0aba" as="font" type="font/woff2" crossorigin>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="/styles/styles.css?v=18b81c65">
+    <link rel="stylesheet" href="/styles/styles.css?v=a8d0b140">
 
     <!-- Structured data: Person -->
     <script type="application/ld+json">

--- a/es/index.html
+++ b/es/index.html
@@ -48,7 +48,7 @@
     <link rel="preload" href="/fonts/poppins-800.woff2?v=60bf0aba" as="font" type="font/woff2" crossorigin>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="/styles/styles.css?v=ff0a7fee">
+    <link rel="stylesheet" href="/styles/styles.css?v=18b81c65">
 
     <!-- Structured data: Person -->
     <script type="application/ld+json">

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <link rel="preload" href="/fonts/poppins-800.woff2?v=60bf0aba" as="font" type="font/woff2" crossorigin>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="/styles/styles.css?v=18b81c65">
+    <link rel="stylesheet" href="/styles/styles.css?v=a8d0b140">
 
     <!-- Structured data: Person -->
     <script type="application/ld+json">

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <link rel="preload" href="/fonts/poppins-800.woff2?v=60bf0aba" as="font" type="font/woff2" crossorigin>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="/styles/styles.css?v=ff0a7fee">
+    <link rel="stylesheet" href="/styles/styles.css?v=18b81c65">
 
     <!-- Structured data: Person -->
     <script type="application/ld+json">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -919,23 +919,52 @@ a {
 @media screen and (max-width: 768px) {
   .hero {
     min-height: 100vh;
+    min-height: 100svh;
+  }
+  .hero::after {
+    background: linear-gradient(180deg, transparent 0%, transparent 35%, rgba(10, 13, 20, 0.85) 70%, rgba(10, 13, 20, 0.96) 100%), radial-gradient(ellipse 110% 85% at 50% 55%, transparent 55%, rgba(10, 13, 20, 0.7) 100%);
   }
   .hero .figure-block {
-    width: 60%;
-    right: -4%;
-    opacity: 0.45;
-    aspect-ratio: 9/16;
-    max-height: 80%;
-    top: 40%;
+    top: 0;
+    right: 0;
+    transform: none;
+    width: 100%;
+    max-height: 58%;
+    aspect-ratio: auto;
+  }
+  .hero .photo-figure {
+    background-position: 60% 18%;
+    background-size: cover;
+    filter: contrast(1.05) brightness(0.55) saturate(0.5);
+    -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 55%, rgba(0, 0, 0, 0.4) 80%, transparent 100%);
+    mask-image: linear-gradient(180deg, #000 0%, #000 55%, rgba(0, 0, 0, 0.4) 80%, transparent 100%);
+  }
+  .hero .photo-tint {
+    opacity: 0.5;
+  }
+  .hero .slab,
+  .hero .slab.green,
+  .hero .slab.dark,
+  .hero .slab.bar,
+  .hero .slab.tag,
+  .hero .slab.tag.b {
+    display: none;
+  }
+  .hero .deco {
+    display: none;
   }
   .hero .hero-content {
-    width: 92%;
+    width: 100%;
     max-width: none;
-    padding: 32px 20px 48px 24px;
+    padding: 28px 22px 40px 22px;
+    bottom: 0;
   }
   .hero h1 {
-    font-size: clamp(1.5rem, 5.4vw, 2rem);
+    font-size: clamp(1.55rem, 5.6vw, 2.1rem);
     line-height: 1.16;
+  }
+  .hero h1 .ln.l1, .hero h1 .ln.l2, .hero h1 .ln.l3, .hero h1 .ln.l4 {
+    padding-left: 0;
   }
   .hero .hero-sub {
     font-size: 0.98rem;
@@ -952,20 +981,17 @@ a {
 }
 @media screen and (max-width: 480px) {
   .hero .figure-block {
-    width: 70%;
-    opacity: 0.32;
-    right: -10%;
-    top: 38%;
+    max-height: 52%;
+  }
+  .hero .photo-figure {
+    background-position: 60% 14%;
+    filter: contrast(1.05) brightness(0.5) saturate(0.5);
   }
   .hero .hero-content {
-    padding: 28px 18px 40px 22px;
+    padding: 24px 18px 36px 18px;
   }
   .hero h1 {
-    font-size: 1.5rem;
-  }
-  .hero .slab.tag,
-  .hero .slab.tag.b {
-    display: none;
+    font-size: 1.55rem;
   }
   .proof-grid {
     grid-template-columns: 1fr;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -935,12 +935,18 @@ a {
   .hero .photo-figure {
     background-position: 60% 18%;
     background-size: cover;
-    filter: contrast(1.05) brightness(0.55) saturate(0.5);
+    filter: contrast(1.15) brightness(0.85) saturate(0.65);
     -webkit-mask-image: linear-gradient(180deg, #000 0%, #000 55%, rgba(0, 0, 0, 0.4) 80%, transparent 100%);
     mask-image: linear-gradient(180deg, #000 0%, #000 55%, rgba(0, 0, 0, 0.4) 80%, transparent 100%);
   }
+  .hero .photo-figure::after {
+    background: linear-gradient(180deg, rgba(23, 29, 49, 0.25) 0%, rgba(15, 19, 33, 0.55) 60%, rgba(10, 13, 20, 0.85) 100%);
+  }
+  .hero .photo-figure::before {
+    opacity: 0.35;
+  }
   .hero .photo-tint {
-    opacity: 0.5;
+    opacity: 0.35;
   }
   .hero .slab,
   .hero .slab.green,
@@ -985,7 +991,7 @@ a {
   }
   .hero .photo-figure {
     background-position: 60% 14%;
-    filter: contrast(1.05) brightness(0.5) saturate(0.5);
+    filter: contrast(1.15) brightness(0.8) saturate(0.65);
   }
   .hero .hero-content {
     padding: 24px 18px 36px 18px;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -879,13 +879,17 @@ a {
   .hero .photo-figure {
     background-position: 60% 18%;
     background-size: cover;
-    filter: contrast(1.05) brightness(.55) saturate(.5);
+    filter: contrast(1.15) brightness(.85) saturate(.65);
     -webkit-mask-image:
       linear-gradient(180deg, #000 0%, #000 55%, rgba(0,0,0,.4) 80%, transparent 100%);
     mask-image:
       linear-gradient(180deg, #000 0%, #000 55%, rgba(0,0,0,.4) 80%, transparent 100%);
+    &::after {
+      background: linear-gradient(180deg, rgba(23, 29, 49, .25) 0%, rgba(15, 19, 33, .55) 60%, rgba(10, 13, 20, .85) 100%);
+    }
+    &::before { opacity: .35; }
   }
-  .hero .photo-tint { opacity: .5; }
+  .hero .photo-tint { opacity: .35; }
 
   // Hide all glitch slabs on mobile — they were positioned for desktop figure box
   // and become huge / misaligned at small widths
@@ -926,7 +930,7 @@ a {
   }
   .hero .photo-figure {
     background-position: 60% 14%;
-    filter: contrast(1.05) brightness(.5) saturate(.5);
+    filter: contrast(1.15) brightness(.8) saturate(.65);
   }
   .hero .hero-content {
     padding: 24px 18px 36px 18px;

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -858,54 +858,81 @@ a {
 @media screen and (max-width: 768px) {
   .hero {
     min-height: 100vh;
+    min-height: 100svh;
+    // Stronger fade behind text so headline reads cleanly when figure is tall
+    &::after {
+      background:
+        linear-gradient(180deg, transparent 0%, transparent 35%, rgba(10, 13, 20, .85) 70%, rgba(10, 13, 20, .96) 100%),
+        radial-gradient(ellipse 110% 85% at 50% 55%, transparent 55%, rgba(10, 13, 20, .7) 100%);
+    }
   }
+
+  // Figure: anchored to top, narrower, much more faded, no longer cropped on the side
   .hero .figure-block {
-    width: 60%;
-    right: -4%;
-    opacity: 0.45;
-    aspect-ratio: 9/16;
-    max-height: 80%;
-    top: 40%;
+    top: 0;
+    right: 0;
+    transform: none;
+    width: 100%;
+    max-height: 58%;
+    aspect-ratio: auto;
   }
+  .hero .photo-figure {
+    background-position: 60% 18%;
+    background-size: cover;
+    filter: contrast(1.05) brightness(.55) saturate(.5);
+    -webkit-mask-image:
+      linear-gradient(180deg, #000 0%, #000 55%, rgba(0,0,0,.4) 80%, transparent 100%);
+    mask-image:
+      linear-gradient(180deg, #000 0%, #000 55%, rgba(0,0,0,.4) 80%, transparent 100%);
+  }
+  .hero .photo-tint { opacity: .5; }
+
+  // Hide all glitch slabs on mobile — they were positioned for desktop figure box
+  // and become huge / misaligned at small widths
+  .hero .slab,
+  .hero .slab.green,
+  .hero .slab.dark,
+  .hero .slab.bar,
+  .hero .slab.tag,
+  .hero .slab.tag.b { display: none; }
+
+  // Hide circuit-trace deco SVG on mobile (was tied to desktop layout)
+  .hero .deco { display: none; }
+
+  // Text takes the bottom, full width, no longer fights the photo
   .hero .hero-content {
-    width: 92%;
+    width: 100%;
     max-width: none;
-    padding: 32px 20px 48px 24px;
+    padding: 28px 22px 40px 22px;
+    bottom: 0;
   }
   .hero h1 {
-    font-size: clamp(1.5rem, 5.4vw, 2rem);
+    font-size: clamp(1.55rem, 5.6vw, 2.1rem);
     line-height: 1.16;
+    .ln.l1, .ln.l2, .ln.l3, .ln.l4 { padding-left: 0; }
   }
   .hero .hero-sub {
     font-size: 0.98rem;
   }
-  .services-list li {
-    width: 100%;
-  }
-  .form-row {
-    grid-template-columns: 1fr;
-  }
-  .section {
-    padding: 3.5rem 1.5rem;
-  }
+
+  .services-list li { width: 100%; }
+  .form-row { grid-template-columns: 1fr; }
+  .section { padding: 3.5rem 1.5rem; }
 }
 
 @media screen and (max-width: 480px) {
   .hero .figure-block {
-    width: 70%;
-    opacity: 0.32;
-    right: -10%;
-    top: 38%;
+    max-height: 52%;
+  }
+  .hero .photo-figure {
+    background-position: 60% 14%;
+    filter: contrast(1.05) brightness(.5) saturate(.5);
   }
   .hero .hero-content {
-    padding: 28px 18px 40px 22px;
+    padding: 24px 18px 36px 18px;
   }
   .hero h1 {
-    font-size: 1.5rem;
-  }
-  .hero .slab.tag,
-  .hero .slab.tag.b {
-    display: none;
+    font-size: 1.55rem;
   }
   .proof-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## What
Mobile-only refinements to the hero (≤768px) after testing on iPhone 15 Pro Max.

- Reposition silhouette photo to the top half with a linear mask
- Hide all glitch slabs and circuit-deco SVG on mobile (they were sized for the desktop figure box and looked oversized)
- Headline cascade collapses to flush-left, full-width
- Stronger bottom gradient → cleaner text contrast over photo
- Brightened photo filter (`brightness .55 → .85`, `contrast 1.05 → 1.15`) so features are recognizable without losing the duotone mood
- Tighter sizing at ≤480px

Commits: `1b1e7b7`, `0556cfc`